### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ A Model Context Protocol (MCP) server for searching NCBI databases, designed for
 🔗 **Related Articles**: Discover relevant research through NCBI's relationship algorithms
 📖 **MeSH Integration**: Search and utilize Medical Subject Headings for precise terminology
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/vitorpavinato-ncbi-mcp-server).
+
 ## Quick Start
 
 ### Prerequisites


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/vitorpavinato-ncbi-mcp-server).